### PR TITLE
setup matchers only

### DIFF
--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -16,5 +16,3 @@ jobs:
         uses: ./
       - name: Verify problem matchers
         run: yarn debug-problem-matchers
-
-

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -9,14 +9,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: actions-ember-testing
-        uses: ./ # Uses an action in the root directory
-        id: actions-ember-testing
-        with:
-          yarn-version: '1.17'
-          node-version: '12'
+      - uses: rwjblue/setup-volta@v1
       - name: Verify node & yarn versions
         run: node -v && yarn -v
+      - name: adding matchers
+        uses: ./
       - name: Verify problem matchers
         run: yarn debug-problem-matchers
 

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -19,5 +19,3 @@ jobs:
         run: node -v && yarn -v
       - name: Verify problem matchers
         run: yarn debug-problem-matchers
-
-

--- a/index.js
+++ b/index.js
@@ -1,31 +1,8 @@
 const core = require('@actions/core');
 const path = require('path');
-const fs = require('fs');
-const {exec} = require('@actions/exec');
-const tc = require('@actions/tool-cache');
 
 async function run() {
     try {
-        // This can be configured for the action
-        let nodeVersion = core.getInput('node-version');
-        let yarnVersion = core.getInput('yarn-version');
-
-        // Install Volta
-        let voltaScriptPath = await tc.downloadTool('https://get.volta.sh');
-        await exec(`bash ${voltaScriptPath}`);
-
-        // Install Node & Yarn
-        if (nodeVersion) {
-            await exec(`$HOME/.volta/volta install node@${nodeVersion}`);
-        }
-
-        if (yarnVersion) {
-            await exec(`$HOME/.volta/volta install yarn@${yarnVersion}`);
-        }
-
-        // Add Volta bins to path
-        console.log(`##[add-path]$HOME/.volta/bin`);
-
         // Add problem matchers for nice output of eslint & tsc errors
         const matchersPath = path.join(__dirname, '.github');
         console.log(`##[add-matcher]${path.join(matchersPath, 'tsc.json')}`);

--- a/index.js
+++ b/index.js
@@ -16,15 +16,15 @@ async function run() {
 
         // Install Node & Yarn
         if (nodeVersion) {
-            await exec(`/home/runner/.volta/volta install node@${nodeVersion}`);
+            await exec(`$HOME/.volta/volta install node@${nodeVersion}`);
         }
 
         if (yarnVersion) {
-            await exec(`/home/runner/.volta/volta install yarn@${yarnVersion}`);
+            await exec(`$HOME/.volta/volta install yarn@${yarnVersion}`);
         }
 
         // Add Volta bins to path
-        console.log(`##[add-path]/home/runner/.volta/bin`);
+        console.log(`##[add-path]$HOME/.volta/bin`);
 
         // Add problem matchers for nice output of eslint & tsc errors
         const matchersPath = path.join(__dirname, '.github');


### PR DESCRIPTION
Hi!

Day or two ago this actions [stopped](https://github.com/Brain-up/brn/pull/159/checks?check_run_id=390703141#step:3:20) working for me (seems like `$HOME !== .runner` anymore).

While trying to fix it I stumbled on [rwjblue/setup-volta](https://github.com/rwjblue/setup-volta) and to me it seems like it would be right to leave this action to setup matchers only. And use `rwjblue/setup-volta` to setup node & yarn:


```diff
name: Ember CI

on: [push]

jobs:
  test:

    runs-on: ubuntu-latest

    steps:
    - uses: actions/checkout@v1
-   - uses: mydea/actions-ember-testing@v1
+   - uses: rwjblue/setup-volta@v1
+   - uses: mydea/actions-ember-testing@v2
    - name: Install dependencies
      run: yarn install
    - name: Run tests
      run: yarn test
    - name: Lint JS
      run: yarn lint:js
    - name: Lint HBS
      run: yarn lint:hbs
```

What do you think?

Downside is that new version must be released which will break those rely on `- uses: mydea/actions-ember-testing@latest`